### PR TITLE
fix: Ensure busy indicator overlay is hidden after operations

### DIFF
--- a/app/src/main/assets/js/app.js
+++ b/app/src/main/assets/js/app.js
@@ -957,27 +957,24 @@ const app = {
 
     // Hides the busy/loading indicator.
     // This method primarily reverses the visual state set by showLoadingIndicator for the 'busy' state.
-    // It does NOT hide the main loadingOverlay itself, as the overall visibility of
-    // loadingOverlay is managed by the app.init -> app.triggerAppStart -> app.hideLoading() flow.
+    // It's called after operations like preset/FX changes (when the app is already running).
     hideLoadingIndicator() {
         if (!this.elements.loadingOverlay || !this.elements.loadingText) return;
 
         this.elements.loadingOverlay.classList.remove('busy-indicator');
 
-        // Reset the loading text if it was showing a busy indicator message.
-        // A more robust approach might involve checking the specific messageKey if available,
-        // or restoring a previously cached main loading message if the intro is still active.
-        // For now, clearing it is a simple way to indicate the busy task is done.
         const busyMessagePrefix = (typeof i18n !== 'undefined' && i18n.translate) ? i18n.translate('loading_changes', 'Applying changes...').substring(0,10) : "Applying";
         if (this.elements.loadingText.textContent.startsWith(busyMessagePrefix)) {
              this.elements.loadingText.textContent = '';
         }
-        // Consider if loadingText display should be reset if it was changed by showLoadingIndicator
-        // e.g., this.elements.loadingText.style.display = 'none';
-        // However, if the main loading text is still supposed to be there (e.g. "Tap to Start"),
-        // clearing our busy message and removing the busy-indicator class should suffice.
 
-        console.log('[App] Busy indicator state removed.');
+        // Add 'hidden' back to the overlay.
+        // This is safe because this hideLoadingIndicator is only called for busy states
+        // *after* the initial app load (due to the isInitialLoad flag in applySoundPreset/applyFxChain).
+        // The main app UI should be visible underneath.
+        this.elements.loadingOverlay.classList.add('hidden');
+
+        console.log('[App] Busy indicator hidden and overlay reset.');
     },
 
     async setScale(scaleId) {
@@ -1810,27 +1807,24 @@ const app = {
 
     // Hides the busy/loading indicator.
     // This method primarily reverses the visual state set by showLoadingIndicator for the 'busy' state.
-    // It does NOT hide the main loadingOverlay itself, as the overall visibility of
-    // loadingOverlay is managed by the app.init -> app.triggerAppStart -> app.hideLoading() flow.
+    // It's called after operations like preset/FX changes (when the app is already running).
     hideLoadingIndicator() {
         if (!this.elements.loadingOverlay || !this.elements.loadingText) return;
 
         this.elements.loadingOverlay.classList.remove('busy-indicator');
 
-        // Reset the loading text if it was showing a busy indicator message.
-        // A more robust approach might involve checking the specific messageKey if available,
-        // or restoring a previously cached main loading message if the intro is still active.
-        // For now, clearing it is a simple way to indicate the busy task is done.
         const busyMessagePrefix = (typeof i18n !== 'undefined' && i18n.translate) ? i18n.translate('loading_changes', 'Applying changes...').substring(0,10) : "Applying";
         if (this.elements.loadingText.textContent.startsWith(busyMessagePrefix)) {
              this.elements.loadingText.textContent = '';
         }
-        // Consider if loadingText display should be reset if it was changed by showLoadingIndicator
-        // e.g., this.elements.loadingText.style.display = 'none';
-        // However, if the main loading text is still supposed to be there (e.g. "Tap to Start"),
-        // clearing our busy message and removing the busy-indicator class should suffice.
 
-        console.log('[App] Busy indicator state removed.');
+        // Add 'hidden' back to the overlay.
+        // This is safe because this hideLoadingIndicator is only called for busy states
+        // *after* the initial app load (due to the isInitialLoad flag in applySoundPreset/applyFxChain).
+        // The main app UI should be visible underneath.
+        this.elements.loadingOverlay.classList.add('hidden');
+
+        console.log('[App] Busy indicator hidden and overlay reset.');
     },
 
     // Collects all application settings that should be persisted.


### PR DESCRIPTION
This commit fixes an issue where the loading message (busy indicator) for operations like preset or FX chain changes would not disappear, leaving the overlay active and blocking the UI.

The regression was introduced when `hideLoadingIndicator` was modified to not hide the main `loadingOverlay` in an attempt to protect the initial visual intro. However, this was incorrect for busy states occurring *after* the app's full initial load.

The fix ensures that `app.hideLoadingIndicator()` now correctly re-adds the `.hidden` class to `this.elements.loadingOverlay`. This is safe because:
1.  The `isInitialLoad` flag passed to `applySoundPreset` and `applyFxChain` prevents `showLoadingIndicator` and `hideLoadingIndicator` from being called during the actual initial application startup sequence.
2.  When these functions *are* called (for changes made after the app is running), `showLoadingIndicator` makes the overlay visible, and `hideLoadingIndicator` must therefore hide it again to reveal the main application UI.

Comments in `showLoadingIndicator` and `hideLoadingIndicator` have been updated to accurately reflect this logic.